### PR TITLE
Implement "Download all" button

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9490,6 +9490,29 @@
         "semver": "^5.3.0"
       }
     },
+    "node-zip": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/node-zip/-/node-zip-1.1.1.tgz",
+      "integrity": "sha1-lNGtZ0o81GoViN1zb0qaeMdX62I=",
+      "requires": {
+        "jszip": "2.5.0"
+      },
+      "dependencies": {
+        "jszip": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/jszip/-/jszip-2.5.0.tgz",
+          "integrity": "sha1-dET9hVHd8+XacZj+oMkbyDCMwnQ=",
+          "requires": {
+            "pako": "~0.2.5"
+          }
+        },
+        "pako": {
+          "version": "0.2.9",
+          "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+          "integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU="
+        }
+      }
+    },
     "noms": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/noms/-/noms-0.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "gatsby-plugin-theme-ui": "^0.2.41",
     "glob": "^7.1.4",
     "lodash.groupby": "^4.6.0",
+    "node-zip": "^1.1.1",
     "pdfkit": "^0.10.0",
     "preval.macro": "^3.0.0",
     "primer-colors": "^1.0.1",

--- a/src/components/button.js
+++ b/src/components/button.js
@@ -1,9 +1,9 @@
 /** @jsx jsx */
 import { jsx } from "theme-ui"
 
-export default function Button(props) {
+export default function Button({ as: Component = "button", ...props }) {
   return (
-    <button
+    <Component
       sx={{
         appearance: "none",
         p: 3,
@@ -15,6 +15,7 @@ export default function Button(props) {
         border: 0,
         borderRadius: 1,
         cursor: "pointer",
+        textDecoration: "none",
         ":disabled": {
           opacity: 0.5,
           cursor: "default",

--- a/src/components/color-mode-toggle.js
+++ b/src/components/color-mode-toggle.js
@@ -14,8 +14,8 @@ export default function ColorModeToggle() {
         setMode(next)
       }}
       sx={{
-        px: 2,
-        py: 1,
+        px: 3,
+        py: 2,
       }}
     >
       {mode}

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -1,8 +1,9 @@
 /** @jsx jsx */
 import { Global } from "@emotion/core"
-import { jsx } from "theme-ui"
-import ColorModeToggle from "../components/color-mode-toggle"
 import { Link } from "gatsby"
+import { jsx } from "theme-ui"
+import ColorModeToggle from "./color-mode-toggle"
+import Button from "./button"
 
 export default function Layout({ children }) {
   return (
@@ -25,7 +26,8 @@ export default function Layout({ children }) {
         sx={{
           display: "flex",
           justifyContent: "space-between",
-          alignItems: "center",
+          alignItems: ["flex-start", "center"],
+          flexDirection: ["column", "row"],
           p: 3,
         }}
       >
@@ -48,7 +50,21 @@ export default function Layout({ children }) {
             WIP
           </span>
         </Link>
-        <ColorModeToggle />
+        <div sx={{ mt: [3, 0] }}>
+          <Button
+            as="a"
+            href="/octicons.zip"
+            download
+            sx={{
+              px: 3,
+              py: 2,
+              mr: 2,
+            }}
+          >
+            Download all
+          </Button>
+          <ColorModeToggle />
+        </div>
       </header>
       <main sx={{ width: "100%", maxWidth: 960, p: [4, 5], mx: "auto" }}>
         {children}


### PR DESCRIPTION
# Problem

Exporting every icon from the Octicons Viewer is a manual and tedious process.

# Solution

This pull request adds a "Download all" button to the top-right of the Octicons Viewer that allows users to download a zip file with SVG and PDF versions of all the icons. 

![image](https://user-images.githubusercontent.com/4608155/67587603-158f7400-f709-11e9-835d-42e1227f5433.png)

Thanks @ashygee for the suggestion!
