### PR TITLE
Add /octicons-v2 path prefix

### DIFF
--- a/now.json
+++ b/now.json
@@ -12,6 +12,11 @@
   ],
   "routes": [
     { "src": "/api/og-image", "dest": "/og-image/index.ts" },
-    { "src": "/(.*)", "dest": "/site/$1" }
+    { "src": "/octicons-v2(/.*)?", "dest": "/site$1" },
+    {
+      "src": "/(.*)",
+      "status": 301,
+      "headers": { "Location": "/octicons-v2/$1" }
+    }
   ]
 }

--- a/site/gatsby-config.js
+++ b/site/gatsby-config.js
@@ -5,6 +5,7 @@ module.exports = {
     imageUrl:
       "https://user-images.githubusercontent.com/10384315/53922681-2f6d3100-402a-11e9-9719-5d1811c8110a.png",
   },
+  pathPrefix: "/octicons-v2",
   plugins: [
     "gatsby-plugin-theme-ui",
     "gatsby-plugin-react-helmet",

--- a/site/package.json
+++ b/site/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "1.0.0",
   "scripts": {
-    "build": "gatsby build",
+    "build": "gatsby build --prefix-paths",
     "develop": "gatsby develop",
     "serve": "gatsby serve",
     "test": "echo \"Write tests! -> https://gatsby.dev/unit-testing \""


### PR DESCRIPTION
All URLs are now prefixed with `/octicons-v2` (e.g. `https://octicons-v2.now.sh/arrow-both-16` → `https://octicons-v2.now.sh/octicons-v2/arrow-both-16`). I also set up a redirect so all the current links don't break.